### PR TITLE
make package compatible with guzzle7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "akeneo/api-php-client": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
         "php": ">=7.2",
-        "php-http/guzzle6-adapter": "^1.0.0 || ^2.0.0",
+        "php-http/guzzle7-adapter": "^1.0.0",
         "spryker/kernel": "^3.0.0"
     },
     "require-dev": {

--- a/src/SprykerEco/Service/AkeneoPim/Dependencies/External/Api/Adapter/Sdk/AkeneoPimSdkFactory.php
+++ b/src/SprykerEco/Service/AkeneoPim/Dependencies/External/Api/Adapter/Sdk/AkeneoPimSdkFactory.php
@@ -9,7 +9,7 @@ namespace SprykerEco\Service\AkeneoPim\Dependencies\External\Api\Adapter\Sdk;
 
 use Akeneo\Pim\ApiClient\AkeneoPimClientBuilder;
 use Akeneo\Pim\ApiClient\AkeneoPimClientInterface;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Client\HttpClient;
 use SprykerEco\Service\AkeneoPim\AkeneoPimConfig;
 


### PR DESCRIPTION
current spryker release uses Guzzle 7 which does not work with this module anymore
+ changed dependency to guzzle7-adapter
+ changed use statement in sdk factory to use guzzle 7 adapter